### PR TITLE
Fix a serious race condition when multiple threads access the same devic...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+trunk (unreleased)
+* Fix a serious race condition exposed when multiple threads access
+  the same block device
+
 1.1.0 (16-Dec-2013)
 * Expose the `blkgetsize` function in the external signature.
 * Regenerate build files with OASIS 0.4.0


### PR DESCRIPTION
...e

The low-level I/O mechanism is:
  seek >>= fun _ ->
  (read | write) >>= fun _ ->

Since threads may switch between the seek and the (read | write), we
must hold an Lwt_mutex.t across this section.

Signed-off-by: David Scott dave.scott@eu.citrix.com
