### PR TITLE
Add `flush` for when operating in buffered mode

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -230,3 +230,14 @@ let resize t new_size_sectors =
           t.info <- { t.info with size_sectors = new_size_sectors };
           return (`Ok ())
         )
+
+let flush t =
+  match t.fd with
+    | None -> return (`Error `Disconnected)
+    | Some fd ->
+      lwt_wrap_exn t.name "fsync" 0L 0
+        (fun () ->
+          Lwt_unix.fsync fd
+          >>= fun () ->
+          return (`Ok ())
+        )

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -158,7 +158,6 @@ let lwt_wrap_exn name op offset length f =
                      (Printf.sprintf "%s: End_of_file at file %s offset %Ld with length %d"
                         op name offset length)))
       | Unix.Unix_error(code, fn, arg) ->
-                      Printf.fprintf stderr "%s\n%!" (Unix.error_message code);
         return (`Error
                   (`Unknown
                      (Printf.sprintf "%s: %s in %s '%s' at file %s offset %Ld with length %d"

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -68,7 +68,7 @@ module Result = struct
 
   let wrap_exn f' x' f x =
     try `Ok (f x)
-    with e -> 
+    with e ->
       `Error (`Unknown (Printf.sprintf "%s %s: %s" f' x' (Printexc.to_string e)))
 end
 
@@ -78,13 +78,13 @@ let blkgetsize filename fd = Result.wrap_exn "BLKGETSIZE" filename Raw.blkgetsiz
 let get_file_size filename fd =
   let open Result in
   stat filename fd
-  >>= fun st -> 
+  >>= fun st ->
   match st.Unix.LargeFile.st_kind with
   | Unix.S_REG -> `Ok st.Unix.LargeFile.st_size
   | Unix.S_BLK -> blkgetsize filename fd
-  | _ -> 
+  | _ ->
     `Error
-      (`Unknown 
+      (`Unknown
          (Printf.sprintf "get_file_size %s: neither a file nor a block device" filename))
 
 (* prefix which signals we want to use buffered I/O *)
@@ -153,20 +153,20 @@ let lwt_wrap_exn name op offset length f =
   Lwt.catch f
     (function
       | End_of_file ->
-        return (`Error 
-                  (`Unknown 
+        return (`Error
+                  (`Unknown
                      (Printf.sprintf "%s: End_of_file at file %s offset %Ld with length %d"
                         op name offset length)))
-      | Unix.Unix_error(code, fn, arg) -> 
+      | Unix.Unix_error(code, fn, arg) ->
                       Printf.fprintf stderr "%s\n%!" (Unix.error_message code);
-        return (`Error 
-                  (`Unknown 
+        return (`Error
+                  (`Unknown
                      (Printf.sprintf "%s: %s in %s '%s' at file %s offset %Ld with length %d"
                         op (Unix.error_message code) fn arg name offset length)))
-      | e -> 
-        return (`Error 
-                  (`Unknown 
-                     (Printf.sprintf "%s: %s at file %s offset %Ld with length %d" 
+      | e ->
+        return (`Error
+                  (`Unknown
+                     (Printf.sprintf "%s: %s at file %s offset %Ld with length %d"
                         op (Printexc.to_string e) name offset length))))
 
 let rec read x sector_start buffers = match buffers with
@@ -195,9 +195,9 @@ let rec write x sector_start buffers = match buffers with
   | [] -> return (`Ok ())
   | b :: bs ->
     begin match x with
-      | { fd = None } -> 
+      | { fd = None } ->
         return (`Error `Disconnected)
-      | { info = { read_write = false } } -> 
+      | { info = { read_write = false } } ->
         return (`Error `Is_read_only)
       | { fd = Some fd } ->
         let offset = Int64.(mul sector_start (of_int x.info.sector_size)) in
@@ -212,9 +212,9 @@ let rec write x sector_start buffers = match buffers with
                ) >>= fun () ->
              return (`Ok ())
           ) >>= function
-        | `Ok () -> 
+        | `Ok () ->
           write x Int64.(add sector_start (div (of_int (Cstruct.len b)) 512L)) bs
-        | `Error x -> 
+        | `Error x ->
           return (`Error x)
     end
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -38,3 +38,7 @@ val resize : t -> int64 -> [ `Ok of unit | `Error of error ] io
 (** [resize t new_size_sectors] attempts to resize the connected device
     to have the given number of sectors. If successful, subsequent calls
     to [get_info] will reflect the new size. *)
+
+val flush : t -> [ `Ok of unit | `Error of error ] io
+(** [flush t] flushes any buffers, if the file has been opened in buffered
+    mode *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -125,6 +125,20 @@ let test_resize () =
         return () in
   Lwt_main.run t
 
+let test_flush () =
+  let t =
+    with_temp_file
+      (fun file ->
+        Block.connect file >>= function
+        | `Error _ -> failwith (Printf.sprintf "Block.connect %s failed" file)
+        | `Ok device1 ->
+          Block.flush device1 >>= function
+           | `Error _ -> failwith (Printf.sprintf "Block.flush %s failed" file)
+           | `Ok () ->
+            Block.disconnect device1
+      ) in
+  Lwt_main.run t
+
 let _ =
   let suite = "block" >::: [
     "test ENOENT" >:: test_enoent;
@@ -134,5 +148,6 @@ let _ =
     *)
     "test read/write after last sector" >:: test_eof;
     "test resize" >:: test_resize;
+    "test flush" >:: test_flush;
   ] in
   OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)


### PR DESCRIPTION
`read` and `write` are defined to be synchronous, but sometimes it's
convenient to open a file in buffered mode, in which case we need to be
able to flush caches.

Signed-off-by: David Scott <dave.scott@unikernel.com>