### PR TITLE
Add Win32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mirage-block-unix
 
 Unix implementation of the Mirage `BLOCK_DEVICE` interface.
 
-This interface exposes raw. unbuffered I/O (via `O_DIRECT`) to files
-and block devices.
+This module provides raw I/O to files and block devices with as little
+caching as possible.
 
 E-mail: <mirageos-devel@lists.xenproject.org>

--- a/lib/blkgetsize_stubs.c
+++ b/lib/blkgetsize_stubs.c
@@ -16,7 +16,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <sys/ioctl.h>
+#endif
 
 #include <fcntl.h>
 #include <string.h>
@@ -70,6 +72,13 @@ int blkgetsize(int fd, uint64_t *psize)
 {
   int ret = ioctl(fd, DIOCGMEDIASIZE, psize);
   return ret;
+}
+
+#elif _WIN32
+
+int blkgetsize(int fd, uint64_t *psize)
+{
+  return 0; /* Will never be called because there are no block device file */
 }
 
 #else

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -21,6 +21,8 @@
 
  module Log = (val Logs.src_log src : Logs.LOG)
 
+let is_win32 = Sys.os_type = "Win32"
+
 type buf = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 type id = string
@@ -114,7 +116,6 @@ let remove_prefix prefix x =
 
 let connect name =
   let buffered, name = remove_prefix buffered_prefix name in
-  let is_win32 = Sys.os_type = "Win32" in
   let openfile, use_fsync = match buffered, is_win32 with
     | true, _ -> Raw.openfile_buffered, false
     | false, false -> Raw.openfile_unbuffered, false

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -257,7 +257,9 @@ let resize t new_size_sectors =
   match t.fd with
     | None -> return (`Error `Disconnected)
     | Some fd ->
-      lwt_wrap_exn t "ftruncate" new_size_bytes
+      if is_win32
+      then return (`Error `Unimplemented)
+      else lwt_wrap_exn t "ftruncate" new_size_bytes
         (fun () ->
           Lwt_unix.LargeFile.ftruncate fd new_size_bytes
           >>= fun () ->

--- a/lib/odirect_stubs.c
+++ b/lib/odirect_stubs.c
@@ -39,7 +39,9 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
   CAMLparam3(filename, rw, perm);
   CAMLlocal1(result);
   int fd;
-
+#ifdef _WIN32
+  caml_failwith("O_DIRECT is not supported on Win32");
+#else
   const char *filename_c = strdup(String_val(filename));
 
   enter_blocking_section();
@@ -65,4 +67,5 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
   if (fd == -1) uerror("open", filename);
   if (ret < 0)  uerror("open", filename);
   CAMLreturn(Val_int(fd));
+#endif /* _WIN32 */
 }

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -202,17 +202,22 @@ let test_flush () =
       ) in
   Lwt_main.run t
 
+let not_implemented_on_windows = [
+  "test resize" >:: test_resize;
+]
+
+let tests = [
+  "test ENOENT" >:: test_enoent;
+  "test open read" >:: test_open_read;
+  (* Doesn't work on travis
+  "test opening a block device" >:: test_open_block;
+  *)
+  "test read/write after last sector" >:: test_eof;
+  "test flush" >:: test_flush;
+  "test write then read" >:: test_write_read;
+  "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
+] @ (if Sys.os_type <> "Win32" then not_implemented_on_windows else [])
+
 let _ =
-  let suite = "block" >::: [
-    "test ENOENT" >:: test_enoent;
-    "test open read" >:: test_open_read;
-    (* Doesn't work on travis
-    "test opening a block device" >:: test_open_block;
-    *)
-    "test read/write after last sector" >:: test_eof;
-    "test resize" >:: test_resize;
-    "test flush" >:: test_flush;
-    "test write then read" >:: test_write_read;
-    "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
-  ] in
+  let suite = "block" >::: tests in
   OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -159,7 +159,7 @@ let find_unused_file () =
   (* Find a filename which doesn't exist *)
   let rec does_not_exist i =
     let name = Printf.sprintf "%s/mirage-block-test.%d.%d"
-      Filename.temp_dir_name (Unix.getpid ()) i in
+      (Filename.get_temp_dir_name ()) (Unix.getpid ()) i in
     if Sys.file_exists name
     then does_not_exist (i + 1)
     else name in


### PR DESCRIPTION
- use `fsync` rather than `open` with `O_DIRECT`
- there's no need for `blkgetsize64` since there are no block device files
- use `open`, `lseek`, `write` instead of `dd` in the tests
- leave `resize` unimplemented for now
