### PR TITLE
Round up size_sectors to include all the data in the file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ocaml/opam:alpine
+ENV OPAMJOBS 8
+WORKDIR /src
+COPY . /src
+RUN opam remote add mirage-dev git://github.com/mirage/mirage-dev
+RUN opam pin add mirage-block-unix /src -n
+RUN opam depext -u -i mirage-block-unix
+RUN opam install mirage-block-unix -y

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -125,6 +125,7 @@ type t = {
      unnecessarily, speeding up sequential read and write *)
   m: Lwt_mutex.t;
   mutable info: Mirage_block.info;
+  size_bytes: int64; (* used to handle the last sector, if the file isn't a multiple *)
   config: Config.t;
   use_fsync_after_write: bool;
 }
@@ -186,20 +187,21 @@ let of_config ({ Config.buffered; sync; path } as config) =
       Unix.close fd;
       fail_with e
     | Error _ -> fail_with "mirage-block-unix:of_config: unknown error"
-    | Ok x ->
+    | Ok size_bytes ->
       get_sector_size path fd >>= function
       | Error (`Msg e) ->
         Unix.close fd;
         fail_with e
       | Error _ -> fail_with "mirage-block-unix:of_config: unknown error"
       | Ok sector_size ->
-        let size_sectors = Int64.(div x (of_int sector_size)) in
+        (* Round up the number of sectors so we don't miss the data on the end *)
+        let size_sectors = Int64.(div (add size_bytes (of_int (sector_size-1))) (of_int sector_size)) in
         let fd = Lwt_unix.of_unix_file_descr fd in
         let m = Lwt_mutex.create () in
         let seek_offset = 0L in
         return ({ fd = Some fd; seek_offset; m;
                   info = { Mirage_block.sector_size; size_sectors; read_write };
-                  config; use_fsync_after_write })
+                  size_bytes; config; use_fsync_after_write })
   with e ->
     Log.err (fun f -> f "connect %s: failed to open file" path);
     fail_with (Printf.sprintf "connect %s: failed to open file" path)
@@ -335,7 +337,20 @@ let read x sector_start buffers =
                       let rec loop = function
                         | [] -> Lwt.return_unit
                         | b :: bs ->
-                          really_read fd b
+                          let virtual_zeroes = Int64.(sub (add offset (of_int (Cstruct.len b))) x.size_bytes) in
+                          ( if virtual_zeroes <= 0L
+                            then really_read fd b
+                            else begin
+                              (* we've had to round up size_sectors to include all the data.
+                                 We expect End_of_file but ensure that the data missing from the
+                                 file is full of zeroes. *)
+                              Cstruct.memset b 0;
+                              Lwt.catch
+                                (fun () -> really_read fd b)
+                                (function
+                                  | End_of_file -> Lwt.return_unit
+                                  | e -> Lwt.fail e)
+                            end )
                           >>= fun () ->
                           x.seek_offset <- Int64.(add x.seek_offset (of_int (Cstruct.len b)));
                           loop bs in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -262,5 +262,6 @@ let tests = [
 ] @ (if Sys.os_type <> "Win32" then not_implemented_on_windows else [])
 
 let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
   let suite = "block" >::: tests in
   OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -204,7 +204,10 @@ let test_not_multiple_of_sectors () =
         Lwt_cstruct.(complete (write fd) buf) >>= fun () ->
         Lwt_unix.close fd >>= fun () ->
         (* We should see 1 sector *)
-        Block.connect file >>= fun device ->
+        (* NB we only test buffered mode because O_DIRECT read on Linux will fail
+           with EINVAL if the file length is not sector-aligned. Arguably buffered
+           mode should actually be the default anyway. *)
+        Block.connect ~buffered:true file >>= fun device ->
         Block.get_info device >>= fun info1 ->
         assert_equal ~printer:Int64.to_string 1L info1.Mirage_block.size_sectors;
         (* We should be able to read 1 sector, padded with zeroes *)

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -27,6 +27,7 @@ depends: [
   "logs"
   "rresult"
   "ounit" {test}
+  "fmt" {test}
 ]
 available: [ ocaml-version >= "4.02.3" ]
 depexts: [


### PR DESCRIPTION
Previously if a file was not a whole multiple of sector_size, we would ignore the last few bytes on the end. This is unfortunate because some programs (e.g. qemu-img) deliberately only allocate a few bytes of the last cluster/sector of a disk.
    
This patch rounds up `size_sectors` such that it includes all the data in the file. The `read` call needs to special case reads which include the last sector: we expect to receive `End_of_file` on those reads internally, which we need to catch. We also guarantee that data not present in the file is read as zero.
