### PR TITLE
Attempt to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="mirage-block-unix"
+   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.02.3
    - DISTRO=debian-testing OCAML_VERSION=4.02.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ env:
    - PACKAGE="mirage-block-unix"
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.02.3
-   - DISTRO=debian-testing OCAML_VERSION=4.02.3
-   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
-   - DISTRO=centos-6 OCAML_VERSION=4.02.3
-   - DISTRO=centos-7 OCAML_VERSION=4.02.3
-   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
-   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3
+   - DISTRO=debian-stable OCAML_VERSION=4.03.0
+   - DISTRO=debian-testing OCAML_VERSION=4.03.0
+   - DISTRO=debian-unstable OCAML_VERSION=4.03.0
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.03.0
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.03.0
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
+   - DISTRO=centos-6 OCAML_VERSION=4.03.0
+   - DISTRO=centos-7 OCAML_VERSION=4.03.0
+   - DISTRO=fedora-23 OCAML_VERSION=4.03.0
+   - DISTRO=alpine-3.3 OCAML_VERSION=4.03.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: c
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-  - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
-dist: trusty
-script: bash -ex .travis-opam.sh && bash -ex travis-coveralls.sh
-sudo: required
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  - OCAML_VERSION=4.02
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.04
+ global:
+   - PACKAGE="mirage-block-unix"
+ matrix:
+   - DISTRO=debian-stable OCAML_VERSION=4.02.3
+   - DISTRO=debian-testing OCAML_VERSION=4.02.3
+   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
+   - DISTRO=centos-6 OCAML_VERSION=4.02.3
+   - DISTRO=centos-7 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
+   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ platform:
 environment:
   CYG_ROOT: "C:\\cygwin"
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
+
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh


### PR DESCRIPTION
Both travis and appveyor need the https://github.com/mirage/mirage-dev remote for `mirage-runtime` and the signature changes.