### PR TITLE
Add another flush behaviour option (mainly for macOS)

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -65,19 +65,35 @@ type 'a io = 'a Lwt.t
 type page_aligned_buffer = Cstruct.t
 
 module Config = struct
+  type sync_behaviour = [
+    | `ToOS
+    | `ToDrive
+  ]
+
+  let sync_behaviour_of_string = function
+    | "0" | "none" -> None
+    | "1" | "drive" -> Some `ToDrive
+    | "os" -> Some `ToOS
+    | _ -> None
+
+  let string_of_sync = function
+    | None -> "none"
+    | Some `ToDrive -> "drive"
+    | Some `ToOS -> "os"
+
   type t = {
     buffered: bool;
-    sync: bool;
+    sync: sync_behaviour option;
     path: string;
   }
 
-  let create ?(buffered = false) ?(sync = true) path =
+  let create ?(buffered = false) ?(sync = Some `ToDrive) path =
     { buffered; sync; path }
 
   let to_string t =
     let query = [
       "buffered", [ if t.buffered then "1" else "0" ];
-      "sync",     [ if t.sync then "1" else "0" ];
+      "sync",     [ string_of_sync t.sync ];
     ] in
     let u = Uri.make ~scheme:"file" ~path:t.path ~query () in
     Uri.to_string u
@@ -88,11 +104,11 @@ module Config = struct
     | Some "file" ->
       let query = Uri.query u in
       let buffered = try List.assoc "buffered" query = [ "1" ] with Not_found -> false in
-      let sync     = try List.assoc "sync"     query = [ "1" ] with Not_found -> false in
+      let sync     = try sync_behaviour_of_string @@ List.hd @@ List.assoc "sync" query with Not_found -> None in
       let path = Uri.(pct_decode @@ path u) in
       Ok { buffered; sync; path }
     | _ ->
-      Error (`Msg "Config.to_string expected a string of the form file://<path>?sync=(0|1)&buffered=(0|1)")
+      Error (`Msg "Config.to_string expected a string of the form file://<path>?sync=(none|os|drive)&buffered=(0|1)")
 end
 
 type t = {
@@ -101,7 +117,6 @@ type t = {
   mutable info: Mirage_block.info;
   config: Config.t;
   use_fsync_after_write: bool;
-  use_fsync_on_flush: bool;
 }
 
 let to_config { config } = config
@@ -152,10 +167,9 @@ let of_config ({ Config.buffered; sync; path } as config) =
       let size_sectors = Int64.(div x (of_int sector_size)) in
       let fd = Lwt_unix.of_unix_file_descr fd in
       let m = Lwt_mutex.create () in
-      let use_fsync_on_flush = sync in
       return ({ fd = Some fd; m;
                 info = { Mirage_block.sector_size; size_sectors; read_write };
-        config; use_fsync_after_write; use_fsync_on_flush })
+        config; use_fsync_after_write })
   with e ->
     Log.err (fun f -> f "connect %s: failed to open file" path);
     fail_with (Printf.sprintf "connect %s: failed to open file" path)
@@ -297,7 +311,7 @@ let resize t new_size_sectors =
              )
         )
 
-external flush_job: Unix.file_descr -> unit Lwt_unix.job = "mirage_block_unix_flush_job"
+external flush_job: Unix.file_descr -> bool -> unit Lwt_unix.job = "mirage_block_unix_flush_job"
 
 let flush t =
   match t.fd with
@@ -305,9 +319,11 @@ let flush t =
   | Some fd ->
     lwt_wrap_exn t "fsync" 0L
       (fun () ->
-         ( if t.use_fsync_on_flush
-           then Lwt_unix.run_job (flush_job (Lwt_unix.unix_file_descr fd))
-           else Lwt.return_unit )
+         ( match t.config.Config.sync with
+           | None -> Lwt.return_unit
+           | Some `ToOS -> Lwt_unix.run_job (flush_job (Lwt_unix.unix_file_descr fd) false)
+           | Some `ToDrive -> Lwt_unix.run_job (flush_job (Lwt_unix.unix_file_descr fd) true)
+         )
          >>= fun () ->
          return (Ok ())
       )

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -87,7 +87,7 @@ module Config = struct
     path: string;
   }
 
-  let create ?(buffered = false) ?(sync = Some `ToDrive) path =
+  let create ?(buffered = false) ?(sync = Some `ToOS) path =
     { buffered; sync; path }
 
   let to_string t =

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -33,14 +33,21 @@ val blkgetsize: string -> Unix.file_descr -> (int64, error) result
     message. *)
 
 module Config: sig
+  type sync_behaviour = [
+    | `ToOS (** flush to the operating system, not necessarily the drive *)
+    | `ToDrive (** flush to the drive *)
+  ]
+
+  val string_of_sync: sync_behaviour option -> string
+
   type t = {
     buffered: bool; (** true if I/O hits the OS disk caches, false if "direct" *)
-    sync: bool; (** true if [flush] flushes all caches, including disk drive caches *)
+    sync: sync_behaviour option;
     path: string; (** path to the underlying file *)
   }
   (** Configuration of a device *)
 
-  val create: ?buffered:bool -> ?sync:bool -> string -> t
+  val create: ?buffered:bool -> ?sync:(sync_behaviour option) -> string -> t
   (** [create ?buffered ?sync path] constructs a configuration referencing the
       file stored at [path]/ *)
 
@@ -52,7 +59,7 @@ module Config: sig
   (** Parse the result of a previous [to_string] invocation *)
 end
 
-val connect : ?buffered:bool -> ?sync:bool -> string -> t io
+val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> string -> t io
 (** [connect ?buffered ?sync path] connects to a block device on the filesystem
     at [path]. By default I/O is unbuffered and fully synchronous. These defaults
     can be changed by supplying the optional arguments [~buffered:true] and

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -183,9 +183,9 @@ let test_parse_print_config config =
     match of_string s with
     | Error (`Msg m) -> failwith m
     | Ok config' ->
-      assert_equal ~printer:string_of_bool config.buffered config'.buffered;
-      assert_equal ~printer:string_of_bool config.sync     config'.sync;
-      assert_equal ~printer:(fun x -> x)   config.path     config'.path;
+      assert_equal ~printer:string_of_bool        config.buffered config'.buffered;
+      assert_equal ~printer:Config.string_of_sync config.sync     config'.sync;
+      assert_equal ~printer:(fun x -> x)          config.path     config'.path;
   )
 
 let not_implemented_on_windows = [
@@ -200,8 +200,9 @@ let tests = [
   *)
   "test read/write after last sector" >:: test_eof;
   "test flush" >:: test_flush;
-  test_parse_print_config { Block.Config.buffered = true; sync = false; path = "C:\\cygwin" };
-  test_parse_print_config { Block.Config.buffered = false; sync = true; path = "/var/tmp/foo.qcow2" };
+  test_parse_print_config { Block.Config.buffered = true; sync = None; path = "C:\\cygwin" };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToOS; path = "/var/tmp/foo.qcow2" };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToDrive; path = "/var/tmp/foo.qcow2" };
   "test write then read" >:: test_write_read;
   "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
 ] @ (if Sys.os_type <> "Win32" then not_implemented_on_windows else [])


### PR DESCRIPTION
Previously we had 2 flush behaviour options:

1. do nothing: fast but obviously unsafe
2. sync as much as possible: on macOS call `fcntl` to push data all the way to the drive (very slow but obviously very safe) and on Unix call `fsync` which pushes data to the OS

Unfortunately on macOS the `fcntl` is extremely slow (~10ms per call) and not implemented properly by all drives.

This PR splits option (2) so now we have

1. do nothing: as before
2. push the data to the OS (i.e. `fsync`)
3. push the data to the drive (i.e. `fcntl`)

The macOS default is switched to (2) (the same as regular Unix). This means we might corrupt data over a host OS crash, but if the host OS crashes we might corrupt data anyway.

This is related to https://github.com/docker/for-mac/issues/668