### PR TITLE
Switch to buffered I/O by default

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -94,7 +94,7 @@ module Config = struct
     path: string;
   }
 
-  let create ?(buffered = false) ?(sync = Some `ToOS) path =
+  let create ?(buffered = true) ?(sync = Some `ToOS) path =
     { buffered; sync; path }
 
   let to_string t =

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -61,8 +61,8 @@ end
 
 val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> string -> t io
 (** [connect ?buffered ?sync path] connects to a block device on the filesystem
-    at [path]. By default I/O is unbuffered and fully synchronous. These defaults
-    can be changed by supplying the optional arguments [~buffered:true] and
+    at [path]. By default I/O is buffered and asynchronous. These defaults
+    can be changed by supplying the optional arguments [~buffered:false] and
     [~sync:false] *)
 
 val resize : t -> int64 -> (unit, write_error) result io


### PR DESCRIPTION
Previously we would use unbuffered I/O which insists that all writes are persisted to the disk before returning success-- this is a good default for databases where data loss is completely unacceptable.

In practice most applications only require write to hit the OS caches, and will tolerate data loss if the host OS occasionally crashes-- this is the default of the `write` API as used by most applications.

This patch switches to buffered I/O by default i.e. we now have the same default as the underlying Unix. This means that

- I/O will not fail if buffers are misaligned (useful given the alignment constraints are hard to determine in practice)
- I/O will be much faster

In the special case where unbuffered I/O is still requested and the target is a block device, this PR also queries the block device for the sector size (i.e. the alignment constraint)

Fixes #56