### PR TITLE
jbuild: make the dependency on lwt.unix explicit

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        mirage_block_unix)
   (public_name mirage-block-unix)
-  (libraries   (cstruct lwt logs uri rresult mirage-block-lwt))
+  (libraries   (cstruct lwt lwt.unix logs uri rresult mirage-block-lwt))
   (wrapped     false)
   (c_names     (odirect_stubs blkgetsize_stubs lseekhole_stubs
                 flush_stubs writev_stubs readv_stubs))


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/9228#issuecomment-302756447

Signed-off-by: David Scott <dave@recoil.org>