### PR TITLE
Attempt to fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,20 @@
 platform:
-  - x86
+  - x64
 
 environment:
-  CYG_ROOT: "C:\\cygwin"
+  CYG_ROOT: "C:\\cygwin64"
+  CYG_CACHE: C:/cygwin64/var/cache/setup
+  CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+  CYG_ARCH: x86_64
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  CYGWIN: "winsymlinks:native"
   PACKAGE: "mirage-block-unix"
 
 install:
+  - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
+  - 'setup.exe -gqnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,rsync,perl,gcc-core,gcc-g++,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel'
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P git -P perl -P mingw64-x86_64-gcc-core"
-  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
+  - curl -L -o C:/cygwin64/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"


### PR DESCRIPTION
This is the same configuration being used in [mirage/shared-memory-ring].
Note we switch also to 64-bit Cygwin.

Signed-off-by: David Scott <dave@recoil.org>