### PR TITLE
Fix build with -safe-string and OCaml 4.06

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ env:
    - PACKAGE="mirage-block-unix"
    - TESTS=true
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.03.0
-   - DISTRO=debian-testing OCAML_VERSION=4.03.0
-   - DISTRO=debian-unstable OCAML_VERSION=4.04.2
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.2
-   - DISTRO=centos-6 OCAML_VERSION=4.03.0
-   - DISTRO=centos-7 OCAML_VERSION=4.03.0
-   - DISTRO=fedora-25 OCAML_VERSION=4.03.0
    - DISTRO=alpine OCAML_VERSION=4.04.2
+   - DISTRO=alpine OCAML_VERSION=4.06.0
+   - DISTRO=debian-stable OCAML_VERSION=4.04.2
+   - DISTRO=debian-stable OCAML_VERSION=4.06.0
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.2
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.06.0
+   - DISTRO=fedora-25 OCAML_VERSION=4.04.2
+   - DISTRO=fedora-25 OCAML_VERSION=4.06.0
+   - DISTRO=centos-6 OCAML_VERSION=4.04.2
+   - DISTRO=centos-6 OCAML_VERSION=4.06.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,20 @@
 platform:
-  - x86
+  - x64
 
 environment:
-  CYG_ROOT: "C:\\cygwin"
+  CYG_ROOT: "C:\\cygwin64"
+  CYG_CACHE: C:/cygwin64/var/cache/setup
+  CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+  CYG_ARCH: x86_64
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  CYGWIN: "winsymlinks:native"
   PACKAGE: "mirage-block-unix"
 
 install:
+  - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
+  - 'setup.exe -gqnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,rsync,perl,gcc-core,gcc-g++,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel'
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P git -P perl -P mingw64-x86_64-gcc-core"
-  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
+  - curl -L -o C:/cygwin64/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -96,11 +96,11 @@ let run ?(env= [| |]) ?stdin cmd args =
     end in
   let read_all fd =
     let b = Buffer.create 128 in
-    let tmp = String.make 4096 '\000' in
+    let tmp = Bytes.make 4096 '\000' in
     let finished = ref false in
     while not !finished do
-      let n = Unix.read fd tmp 0 (String.length tmp) in
-      Buffer.add_substring b tmp 0 n;
+      let n = Unix.read fd tmp 0 (Bytes.length tmp) in
+      Buffer.add_subbytes b tmp 0 n;
       finished := n = 0
     done;
     Buffer.contents b in
@@ -133,8 +133,8 @@ let run ?(env= [| |]) ?stdin cmd args =
     begin match stdin with
       | None -> ()
       | Some txt ->
-        let n = Unix.write stdin_writable txt 0 (String.length txt) in
-        if n <> (String.length txt)
+        let n = Unix.write stdin_writable txt 0 (Bytes.length txt) in
+        if n <> (Bytes.length txt)
         then failwith (Printf.sprintf "short write to process stdin: only wrote %d bytes" n);
     end;
     close stdin_writable;
@@ -173,7 +173,7 @@ let with_temp_file f =
        finally
          (fun () ->
             ignore(Unix.lseek fd 1048575 Unix.SEEK_CUR);
-            ignore(Unix.write fd "\000" 0 1)) (* will write at least 1 *)
+            ignore(Unix.write fd (Bytes.make 1 '\000') 0 1)) (* will write at least 1 *)
          (fun () -> Unix.close fd);
        f path
     ) (fun () ->


### PR DESCRIPTION
This also

- includes the appveyor fix from #81 to pre-empt the appveyor failure.
- focuses the travis testing matrix on OCaml 4.04.2 and 4.06.0, across a range of distributions