### PR TITLE
opam: depend on conf-linux-libc-dev on Linux

### DIFF
--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -27,8 +27,6 @@ depends: [
   "logs"
   "ounit" {test}
   "fmt" {test}
+  "conf-linux-libc-dev" {os = "linux"}
 ]
 available: [ ocaml-version >= "4.03.0" ]
-depexts: [
- [["alpine"] ["linux-headers"]]
-]


### PR DESCRIPTION
This replaces the (incomplete) list of depexts.

See https://github.com/ocaml/opam-repository/pull/10852#discussion_r153066469

Signed-off-by: David Scott <dave@recoil.org>