### PR TITLE
Optionally allow the file to be locked when it is opened

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## v2.9.0 (2017-12-07)
+* Add support for `flock` file locking
+
 ## v2.8.4 (2017-11-25)
 * opam: add lower bound on uri.1.9.0
 * fix build with appveyor

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -44,12 +44,13 @@ module Config: sig
     buffered: bool; (** true if I/O hits the OS disk caches, false if "direct" *)
     sync: sync_behaviour option;
     path: string; (** path to the underlying file *)
+    lock: bool; (** true if the file should be locked preventing concurrent modification *)
   }
   (** Configuration of a device *)
 
-  val create: ?buffered:bool -> ?sync:(sync_behaviour option) -> string -> t
-  (** [create ?buffered ?sync path] constructs a configuration referencing the
-      file stored at [path]/ *)
+  val create: ?buffered:bool -> ?sync:(sync_behaviour option) -> ?lock:bool -> string -> t
+  (** [create ?buffered ?sync ?lock path] constructs a configuration referencing the
+      file stored at [path]. *)
 
   val to_string: t -> string
   (** Marshal a config into a string of the form
@@ -59,11 +60,12 @@ module Config: sig
   (** Parse the result of a previous [to_string] invocation *)
 end
 
-val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> string -> t io
-(** [connect ?buffered ?sync path] connects to a block device on the filesystem
-    at [path]. By default I/O is buffered and asynchronous. These defaults
+val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> ?lock:bool -> string -> t io
+(** [connect ?buffered ?sync ?lock path] connects to a block device on the filesystem
+    at [path]. By default I/O is buffered and asynchronous. By default the file
+    is unlocked. These defaults
     can be changed by supplying the optional arguments [~buffered:false] and
-    [~sync:false] *)
+    [~sync:false] [~lock:true] *)
 
 val resize : t -> int64 -> (unit, write_error) result io
 (** [resize t new_size_sectors] attempts to resize the connected device

--- a/lib/flock_stubs.c
+++ b/lib/flock_stubs.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define _GNU_SOURCE
+
+#include <sys/file.h>
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/bigarray.h>
+
+/* ocaml/ocaml/unixsupport.c */
+extern void uerror(char *cmdname, value cmdarg);
+
+CAMLprim value stub_flock(value fd, value ex, value nb){
+  CAMLparam3(fd, ex, nb);
+  int result;
+#ifdef _WIN32
+  caml_failwith("flock is not supported on Win32");
+#else
+  const int c_fd = Int_val(fd);
+  int flags = 0;
+  if (Bool_val(ex)) {
+    flags |= LOCK_EX;
+  } else {
+    flags |= LOCK_SH;
+  }
+  if (Bool_val(nb)) {
+    flags |= LOCK_NB;
+  }
+  enter_blocking_section();
+  result = flock(c_fd, flags);
+  leave_blocking_section();
+
+  if (result != 0) {
+    uerror("flock", fd);
+  }
+  CAMLreturn(Val_unit);
+#endif /* _WIN32 */
+}

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -4,4 +4,4 @@
   (libraries   (cstruct-lwt logs uri rresult mirage-block-lwt))
   (wrapped     false)
   (c_names     (odirect_stubs blkgetsize_stubs lseekhole_stubs
-                flush_stubs writev_stubs readv_stubs))))
+                flush_stubs writev_stubs readv_stubs flock_stubs))))

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -256,9 +256,9 @@ let tests = [
   *)
   "test read/write after last sector" >:: test_eof;
   "test flush" >:: test_flush;
-  test_parse_print_config { Block.Config.buffered = true; sync = None; path = "C:\\cygwin" };
-  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToOS; path = "/var/tmp/foo.qcow2" };
-  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToDrive; path = "/var/tmp/foo.qcow2" };
+  test_parse_print_config { Block.Config.buffered = true; sync = None; path = "C:\\cygwin"; lock = false };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToOS; path = "/var/tmp/foo.qcow2"; lock = false };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToDrive; path = "/var/tmp/foo.qcow2"; lock = true };
   "test write then read" >:: test_write_read;
   "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
   "files which aren't a whole number of sectors" >:: test_not_multiple_of_sectors;


### PR DESCRIPTION
This patch uses `flock` on Unix to acquire a shared lock (in read/only
mode) and an exclusive lock (in read/write mode). This prevents the
same disk being accessed by two processes.

Note that this support is Unix only. The default (no locking) is unchanged.

Signed-off-by: David Scott <dave@recoil.org>