### PR TITLE
Add DISCARD/ TRIM support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+Dockerfile.*
+stress.yml

--- a/Dockerfile.stress
+++ b/Dockerfile.stress
@@ -1,0 +1,16 @@
+FROM ocaml/opam:alpine as build
+ENV OPAMJOBS 8
+RUN opam remote add mirage-dev git://github.com/mirage/mirage-dev
+RUN opam pin add diet git://github.com/djs55/ocaml-diet -n
+RUN opam depext -u -i mirage-block-unix
+RUN opam install mirage-block-unix -y
+RUN opam install ounit diet -y
+WORKDIR /src
+COPY . /src
+RUN opam pin add mirage-block-unix /src -n
+USER 0
+RUN opam config --root /home/opam/.opam exec -- sh -c 'jbuilder build lib_test/stress.exe'
+
+FROM alpine
+COPY --from=build /src/_build/default/lib_test/stress.exe /
+

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ uninstall:
 clean:
 	jbuilder clean
 
+.PHONY: vm-test
+vm-test:
+	echo "The VM test requires the linuxkit tool to be installed."
+	docker build -t stress -f Dockerfile.stress  .
+	linuxkit build stress.yml
+	echo "If the VM exits, then the test was successful. Otherwise the logs are in /var/log/stress*"
+	linuxkit run -disk `pwd`/stress.img,size=16M stress
+
 REPO=../../mirage/opam-repository
 PACKAGES=$(REPO)/packages
 # until we have https://github.com/ocaml/opam-publish/issues/38

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   FORK_BRANCH: master
   PACKAGE: mirage-block-unix
   CYG_ROOT: C:\cygwin64
+  PINS: "diet:git://github.com/djs55/ocaml-diet"
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -525,6 +525,7 @@ let discard t sector n =
   | { fd = Some fd } ->
     if is_win32
     then return (Error `Unimplemented)
+    else if n = 0L then Lwt.return (Ok ())
     else lwt_wrap_exn t "discard" sector
       (fun () ->
         let fd = Lwt_unix.unix_file_descr fd in

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -85,6 +85,11 @@ val seek_mapped: t -> int64 -> (int64, error) result io
     device which may have data in it (typically this is the next mapped
     region) *)
 
+val discard: t -> int64 -> int64 -> (unit, write_error) result io
+(** [discard sector n] signals that the [n] sectors starting at [sector]
+    are no longer needed and the contents may be discarded. Note the contents
+    may not actually be deleted: this is not a "secure erase". *)
+
 val to_config: t -> Config.t
 (** [to_config t] returns the configuration of a device *)
 

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -32,6 +32,10 @@ val blkgetsize: string -> Unix.file_descr -> (int64, error) result
     given by [fd]. [path] is only used to construct a human-readable error
     message. *)
 
+val ftruncate: Lwt_unix.file_descr -> int64 -> unit Lwt.t
+(** [ftruncate fd size]: changes the size of the file backed by [fd]
+    to [size]. This function works on Unix and Windows. *)
+
 module Config: sig
   type sync_behaviour = [
     | `ToOS (** flush to the operating system, not necessarily the drive *)

--- a/lib/chsize_stubs.c
+++ b/lib/chsize_stubs.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#ifndef _WIN32
+#endif
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/signals.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/unixsupport.h>
+
+#include "lwt_unix.h"
+
+struct job_chsize {
+  struct lwt_unix_job job;
+  int fd;
+  uint64_t size;
+  int errno_copy;
+};
+
+#ifdef _WIN32
+
+#include <io.h>
+
+#else
+
+#define errno_t int
+
+#define Handle_val(x) Int_val(x)
+
+errno_t _chsize_s(int fd, int64_t size) {
+  return ENOTSUP;
+}
+
+#endif
+#include <stdio.h>
+static void worker_chsize(struct job_chsize *job)
+{
+fprintf(stderr, "fd = %d\n", job->fd);
+  job->errno_copy = _chsize_s(job->fd, job->size);
+}
+
+static value result_chsize(struct job_chsize *job)
+{
+  CAMLparam0 ();
+  int errno_copy = job->errno_copy;
+  lwt_unix_free_job(&job->job);
+  if (errno_copy != 0) {
+    unix_error(errno_copy, "chsize_s", Nothing);
+  }
+  CAMLreturn(Val_int(0));
+}
+
+CAMLprim
+value mirage_block_unix_chsize_job(value fd, value size)
+{
+  CAMLparam2(fd, size);
+
+  LWT_UNIX_INIT_JOB(job, chsize, 0);
+#ifdef _WIN32
+  job->fd = _open_osfhandle((intptr_t)Handle_val(fd), 0);
+#else
+  job->fd = Int_val(fd);
+#endif
+  job->size = Int64_val(size);
+  job->errno_copy = 0;
+
+  CAMLreturn(lwt_unix_alloc_job(&(job->job)));
+}
+

--- a/lib/discard_stubs.c
+++ b/lib/discard_stubs.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2018 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if defined(__linux__)
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+
+#ifndef BLKDISCARD
+# define BLKDISCARD	_IO(0x12,119)
+#endif
+
+#endif
+
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <assert.h>
+
+#include <sys/param.h>
+#include <sys/mount.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+#include <caml/unixsupport.h>
+#include <caml/callback.h>
+
+#include "lwt_unix.h"
+
+struct job_discard {
+  struct lwt_unix_job job;
+  uint64_t offset;
+  uint64_t length;
+  int fd;
+  int errno_copy;
+  const char *error_fn;
+};
+
+#ifndef ALIGNUP
+#define ALIGNUP(x, a) (((x - 1) & ~(a - 1)) + a)
+#endif
+
+#ifndef ALIGNDOWN
+#define ALIGNDOWN(x, a) (-(a) & (x))
+#endif
+
+static void worker_discard(struct job_discard *job)
+{
+  job->errno_copy = ENOTSUP;
+  job->error_fn = "unknown";
+#if defined(__APPLE__)
+  /* When a Block device is backed by a file we currently report the sector size as
+     512. The macOS F_PUNCHHOLE API requires arguments to be aligned to the `fstatfs`
+     `f_bsize` (typically 4096 bytes). Therefore we must manually zero leading and
+     trailing unaligned offsets. */
+  struct statfs fsbuf;
+  if (fstatfs(job->fd, &fsbuf) == -1) {
+    job->errno_copy = errno;
+    job->error_fn = "fstatfs";
+    return;
+  }
+  size_t delete_alignment = (size_t)fsbuf.f_bsize;
+  off_t fp_offset = job->offset;
+  off_t fp_length = job->length;
+
+  size_t aligned_offset = ALIGNUP(fp_offset, delete_alignment);
+  if (aligned_offset != fp_offset) {
+    size_t len_to_zero = aligned_offset - fp_offset;
+    assert(len_to_zero <= delete_alignment);
+    void *zero_buf = (void*)malloc(len_to_zero);
+    bzero(zero_buf, len_to_zero);
+    ssize_t written = pwrite(job->fd, zero_buf, len_to_zero, (off_t) fp_offset);
+    if (written == -1) {
+      job->errno_copy = errno;
+      job->error_fn = "pwrite";
+      return;
+    }
+    fp_offset += len_to_zero;
+    fp_length -= len_to_zero;
+  }
+
+  size_t aligned_length = ALIGNDOWN(fp_length, delete_alignment);
+  if (aligned_length != fp_length) {
+    size_t len_to_zero = fp_length - aligned_length;
+    assert(len_to_zero <= delete_alignment);
+    fp_length -= len_to_zero;
+    void *zero_buf = (void*)malloc(len_to_zero);
+    bzero(zero_buf, len_to_zero);
+    ssize_t written = pwrite(job->fd, zero_buf, len_to_zero, (off_t) (fp_offset + fp_length));
+    if (written == -1) {
+      job->errno_copy = errno;
+      job->error_fn = "pwrite";
+      return;
+    }
+  }
+  struct fpunchhole arg = { .fp_flags = 0, .reserved = 0, .fp_offset = (off_t) fp_offset, .fp_length = (off_t) fp_length };
+  if (fcntl(job->fd, F_PUNCHHOLE, &arg) == -1){
+    job->errno_copy = errno;
+    job->error_fn = "fcntl(F_PUNCHHOLE)";
+    return;
+  }
+  job->errno_copy = 0;
+  return;
+#elif defined(__linux__)
+  /* Check if it's a file or a block device */
+  struct stat buf;
+  if (fstat(job->fd, &buf) == -1) {
+    job->errno_copy = errno;
+    job->error_fn = "fstat";
+    return;
+  }
+  if (S_ISBLK(buf.st_mode)) {
+    uint64_t range[2] = { job->offset, job->length };
+    if (ioctl(job->fd, BLKDISCARD, &range)) {
+      job->errno_copy = errno;
+      job->error_fn = "ioctl";
+      return;
+    }
+    job->errno_copy = 0;
+    return;
+  }
+
+  if (fallocate(job->fd, FALLOC_FL_PUNCH_HOLE, job->offset, job->length) == -1){
+    job->errno_copy = errno;
+    job->error_fn = "fallocate";
+    return;
+  }
+#endif
+}
+
+static value result_discard(struct job_discard *job)
+{
+  CAMLparam0 ();
+  int errno_copy = job->errno_copy;
+  char *error_fn = (char*)job->error_fn;
+  lwt_unix_free_job(&job->job);
+  if (errno_copy != 0) {
+    unix_error(errno_copy, error_fn, Nothing);
+  }
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim
+value mirage_block_unix_discard_job(value handle, value offset, value length)
+{
+  CAMLparam3(handle, offset, length);
+  LWT_UNIX_INIT_JOB(job, discard, 0);
+  job->fd = Int_val(handle);
+  job->offset = Int64_val(offset);
+  job->length = Int64_val(length);
+  job->errno_copy = 0;
+  job->error_fn = "";
+  CAMLreturn(lwt_unix_alloc_job(&(job->job)));
+}

--- a/lib/discard_stubs.c
+++ b/lib/discard_stubs.c
@@ -151,12 +151,18 @@ static void worker_discard(struct job_discard *job)
     job->errno_copy = 0;
     return;
   }
-
+#if defined(FALLOC_FL_PUNCH_HOLE)
   if (fallocate(job->fd, FALLOC_FL_PUNCH_HOLE, job->offset, job->length) == -1){
     job->errno_copy = errno;
     job->error_fn = "fallocate";
     return;
   }
+#else
+  job->errno_copy = ENOSYS;
+  job->error_fn = "fallocate";
+  return;
+#endif
+
 #endif
 }
 

--- a/lib/discard_stubs.c
+++ b/lib/discard_stubs.c
@@ -34,8 +34,10 @@
 #include <fcntl.h>
 #include <assert.h>
 
+#if !defined(WIN32)
 #include <sys/param.h>
 #include <sys/mount.h>
+#endif
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -4,4 +4,5 @@
   (libraries   (cstruct-lwt logs uri rresult mirage-block-lwt))
   (wrapped     false)
   (c_names     (odirect_stubs blkgetsize_stubs lseekhole_stubs
-                flush_stubs writev_stubs readv_stubs flock_stubs))))
+                flush_stubs writev_stubs readv_stubs flock_stubs
+                discard_stubs))))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -5,4 +5,4 @@
   (wrapped     false)
   (c_names     (odirect_stubs blkgetsize_stubs lseekhole_stubs
                 flush_stubs writev_stubs readv_stubs flock_stubs
-                discard_stubs))))
+                discard_stubs chsize_stubs))))

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,6 +1,8 @@
 (executables
- ((names (benchmark test))
-  (libraries   (lwt cstruct.lwt mirage-block-unix cstruct io-page io-page.unix logs logs.fmt oUnit))
+ ((names (benchmark test stress))
+  (libraries   (lwt cstruct.lwt mirage-block-unix cstruct io-page io-page.unix
+                logs logs.fmt oUnit diet))
+  (preprocess (pps (ppx_sexp_conv)))
 ))
 
 (alias

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -9,3 +9,8 @@
  ((name    runtest)
   (deps    (test.exe))
   (action  (run ${<} -runner sequential))))
+
+(alias
+ ((name    runtest)
+  (deps    (stress.exe))
+  (action  (run ${<}))))

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -235,7 +235,7 @@ let create_file path nsectors =
 let _ =
   Logs.set_reporter (Logs_fmt.reporter ());
   let sectors = ref 65536 in
-  let stop_after = ref 1024 in
+  let stop_after = ref 64 in
   let path = ref "" in
   Arg.parse [
     "-path", Arg.Set_string path, "Path of file or block device (default: create a fresh file)";

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -156,7 +156,7 @@ module Make(B: DISCARDABLE) = struct
       if !nr_iterations = stop_after then Lwt.return_unit else begin
         let r = Random.int 21 in
         (* A random action: mostly a write or a discard, occasionally a compact *)
-        ( if 0 <= r && r < 10 then begin
+        ( if 0 <= r && r < 20 then begin
             let sector = Random.int64 nr_sectors in
             let n = Random.int64 (Int64.sub nr_sectors sector) in
             if !debug then Printf.fprintf stderr "write %Ld %Ld\n%!" sector n;

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -228,7 +228,7 @@ let create_file path nsectors =
   let open Lwt.Infix in
   Lwt_unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC; Lwt_unix.O_WRONLY ] 0o0644
   >>= fun fd ->
-  Lwt_unix.ftruncate fd (Int64.to_int nsectors * 512)
+  Block.ftruncate fd (Int64.mul nsectors 512L)
   >>= fun () ->
   Lwt_unix.close fd
 

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -1,0 +1,248 @@
+(*
+ * Copyright (C) 2016-2018 Docker Inc
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+module type DISCARDABLE = sig
+  include Mirage_block_lwt.S
+
+  val discard: t -> int64 -> int64 -> (unit, write_error) result io
+end
+
+let debug = ref false
+
+module Make(B: DISCARDABLE) = struct
+  module SectorSet = Diet.Make(struct
+    include Int64
+    open Sexplib.Std
+    type t' = int64 [@@deriving sexp]
+    let sexp_of_t = sexp_of_t'
+    let t_of_sexp = t'_of_sexp
+  end)
+
+
+  (* Randomly write and discard, checking with read whether the expected data is in
+    each sector. By convention we write the sector index into each sector so we
+    can detect if they permute or alias. *)
+  let random_write_discard stop_after block =
+    let open Lwt.Infix in
+    B.get_info block
+    >>= fun info ->
+    let nr_sectors = info.Mirage_block.size_sectors in
+  
+    (* add to this set on write, remove on discard *)
+    let written = ref SectorSet.empty in
+    let i = SectorSet.Interval.make 0L (Int64.pred info.Mirage_block.size_sectors) in
+    let empty = ref SectorSet.(add i empty) in
+    let nr_iterations = ref 0 in
+
+    let buffer_size = 1048576 in (* perform 1MB of I/O at a time, maximum *)
+    let buffer_size_sectors = Int64.of_int (buffer_size / info.Mirage_block.sector_size) in
+    let write_buffer = Io_page.(to_cstruct @@ get (buffer_size / page_size)) in
+    let read_buffer = Io_page.(to_cstruct @@ get (buffer_size / page_size)) in
+
+    let write x n =
+      assert (Int64.add x n <= nr_sectors);
+      let one_write x n =
+        assert (n <= buffer_size_sectors);
+        let buf = Cstruct.sub write_buffer 0 (Int64.to_int n * info.Mirage_block.sector_size) in
+        let rec for_each_sector x remaining =
+          if Cstruct.len remaining = 0 then () else begin
+            let sector = Cstruct.sub remaining 0 512 in
+            (* Only write the first byte *)
+            Cstruct.BE.set_uint64 sector 0 x;
+            for_each_sector (Int64.succ x) (Cstruct.shift remaining 512)
+          end in
+        for_each_sector x buf;
+        B.write block x [ buf ]
+        >>= function
+        | Error _ -> failwith "write"
+        | Ok () -> Lwt.return_unit in
+      let rec loop x n =
+        if n = 0L then Lwt.return_unit else begin
+          let n' = min buffer_size_sectors n in
+          one_write x n'
+          >>= fun () ->
+          loop (Int64.add x n') (Int64.sub n n')
+        end in
+      loop x n
+      >>= fun () ->
+      if n > 0L then begin
+        let y = Int64.(add x (pred n)) in
+        let i = SectorSet.Interval.make x y in
+        written := SectorSet.add i !written;
+        empty := SectorSet.remove i !empty;
+      end;
+      Lwt.return_unit in
+
+    let discard x n =
+      assert (Int64.add x n <= nr_sectors);
+      let y = Int64.(add x (pred n)) in
+      B.discard block x n
+      >>= function
+      | Error _ -> failwith "discard"
+      | Ok () ->
+      if n > 0L then begin
+        let i = SectorSet.Interval.make x y in
+        written := SectorSet.remove i !written;
+        empty := SectorSet.add i !empty;
+      end;
+      Lwt.return_unit in
+    let check_contents sector buf expected =
+      (* Only check the first byte: assume the rest of the sector are the same *)
+      let actual = Cstruct.BE.get_uint64 buf 0 in
+      if actual <> expected
+      then failwith (Printf.sprintf "contents of sector %Ld incorrect: expected %Ld but actual %Ld" sector expected actual) in
+    let check_all_clusters () =
+      let rec check p set = match SectorSet.choose set with
+        | i ->
+          let x = SectorSet.Interval.x i in
+          let y = SectorSet.Interval.y i in
+          begin
+            let n = Int64.(succ (sub y x)) in
+            assert (Int64.add x n <= nr_sectors);
+            let one_read x n =
+              assert (n <= buffer_size_sectors);
+              let buf = Cstruct.sub read_buffer 0 (Int64.to_int n * info.Mirage_block.sector_size) in
+              B.read block x [ buf ]
+              >>= function
+              | Error _ -> failwith "read"
+              | Ok () ->
+                let rec for_each_sector x remaining =
+                  if Cstruct.len remaining = 0 then () else begin
+                    let expected = p x in
+                    let sector = Cstruct.sub remaining 0 512 in
+                    check_contents x sector expected;
+                    for_each_sector (Int64.succ x) (Cstruct.shift remaining 512)
+                  end in
+                for_each_sector x buf;
+                Lwt.return_unit in
+            let rec loop x n =
+              if n = 0L then Lwt.return_unit else begin
+                let n' = min buffer_size_sectors n in
+                one_read x n'
+                >>= fun () ->
+                loop (Int64.add x n') (Int64.sub n n')
+              end in
+            loop x n
+            >>= fun () ->
+            check p (SectorSet.remove i set)
+          end
+        | exception Not_found ->
+          Lwt.return_unit in
+      Lwt.pick [
+        check (fun _ -> 0L) !empty;
+        Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "check empty")
+      ]
+      >>= fun () ->
+      Lwt.pick [
+        check (fun x -> x) !written;
+        Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "check written")
+      ] in
+    Random.init 0;
+    let rec loop () =
+      incr nr_iterations;
+      if !nr_iterations = stop_after then Lwt.return_unit else begin
+        let r = Random.int 21 in
+        (* A random action: mostly a write or a discard, occasionally a compact *)
+        ( if 0 <= r && r < 10 then begin
+            let sector = Random.int64 nr_sectors in
+            let n = Random.int64 (Int64.sub nr_sectors sector) in
+            if !debug then Printf.fprintf stderr "write %Ld %Ld\n%!" sector n;
+            Printf.printf ".%!";
+            Lwt.pick [
+              write sector n;
+              Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "write timeout")
+            ]
+          end else begin
+            let sector = Random.int64 nr_sectors in
+            let n = Random.int64 (Int64.sub nr_sectors sector) in
+            if !debug then Printf.fprintf stderr "discard %Ld %Ld\n%!" sector n;
+            Printf.printf "-%!";
+            Lwt.pick [
+              discard sector n;
+              Lwt_unix.sleep 30. >>= fun () -> Lwt.fail (Failure "discard timeout")
+            ]
+          end )
+        >>= fun () ->
+        check_all_clusters ();
+        >>= fun () ->
+        loop ()
+      end in
+    Lwt.catch loop
+      (fun e ->
+        Printf.fprintf stderr "Test failed on iteration # %d\n%!" !nr_iterations;
+        Printexc.print_backtrace stderr;
+        let s = Sexplib.Sexp.to_string_hum (SectorSet.sexp_of_t !written) in
+        Lwt_io.open_file ~flags:[Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] ~perm:0o644 ~mode:Lwt_io.output "/tmp/written.sexp"
+        >>= fun oc ->
+        Lwt_io.write oc s
+        >>= fun () ->
+        Lwt_io.close oc
+        >>= fun () ->
+        let s = Sexplib.Sexp.to_string_hum (SectorSet.sexp_of_t !empty) in
+        Lwt_io.open_file ~flags:[Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] ~perm:0o644 ~mode:Lwt_io.output "/tmp/empty.sexp"
+        >>= fun oc ->
+        Lwt_io.write oc s
+        >>= fun () ->
+        Lwt_io.close oc
+        >>= fun () ->
+        Lwt.fail e
+      )
+end
+
+module Test = Make(Block)
+
+let create_file path nsectors =
+  let open Lwt.Infix in
+  Lwt_unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC; Lwt_unix.O_WRONLY ] 0o0644
+  >>= fun fd ->
+  Lwt_unix.ftruncate fd (Int64.to_int nsectors * 512)
+  >>= fun () ->
+  Lwt_unix.close fd
+
+let _ =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  let sectors = ref 65536 in
+  let stop_after = ref 1024 in
+  Arg.parse [
+    "-sectors", Arg.Set_int sectors, Printf.sprintf "Total number of sectors (default %d)" !sectors;
+    "-stop-after", Arg.Set_int stop_after, Printf.sprintf "Number of iterations to stop after (default: 1024, 0 means never)";
+    "-debug", Arg.Set debug, "enable debug";
+  ] (fun x ->
+      Printf.fprintf stderr "Unexpected argument: %s\n" x;
+      exit 1
+    ) "Perform random read/write/discard/compact operations on a file or block device";
+
+  Lwt_main.run begin
+    let open Lwt.Infix in
+    let sectors = Int64.of_int (!sectors) in
+    let path = Filename.concat "." (Int64.to_string sectors) ^ ".compact" in
+
+    create_file path sectors
+    >>= fun () ->
+    Block.connect path
+    >>= fun block ->
+
+    Lwt.catch
+      (fun () ->
+        Test.random_write_discard (!stop_after) block
+        >>= fun () ->
+        Lwt_unix.unlink path
+      ) (fun e ->
+        Printf.fprintf stderr "Block device file is: %s\n%!" path;
+        (* Don't delete it so it can be analysed *)
+        Lwt.fail e
+      )
+  end

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -264,6 +264,9 @@ let _ =
       (fun () ->
         Test.random_write_discard (!stop_after) (not path_already_exists) block
         >>= fun () ->
+        (* Windows will fail the unlink if the file is open *)
+        Block.disconnect block
+        >>= fun () ->
         if not path_already_exists then Lwt_unix.unlink path else Lwt.return_unit
       ) (fun e ->
         Printf.fprintf stderr "Block device file is: %s\n%!" path;

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -26,6 +26,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "logs"
   "ounit" {test}
+  "diet" {test}
   "fmt" {test}
   "ppx_tools" {test}
   "ppx_sexp_conv" {test}

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -27,6 +27,9 @@ depends: [
   "logs"
   "ounit" {test}
   "fmt" {test}
+  "ppx_tools" {test}
+  "ppx_sexp_conv" {test}
+  "ppx_type_conv" {test}
 ]
 available: [ ocaml-version >= "4.03.0" ]
 depexts: [

--- a/stress.yml
+++ b/stress.yml
@@ -1,0 +1,25 @@
+kernel:
+  image: linuxkit/kernel:4.9.82
+  cmdline: "console=tty0 console=ttyS0 console=ttyAMA0"
+init:
+  - linuxkit/init:d899eee3560a40aa3b4bdd67b3bb82703714b2b9
+  - linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731
+  - linuxkit/containerd:37e397ebfc6bd5d8e18695b121166ffd0cbfd9f0
+onboot:
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:v0.2
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+services:
+  - name: getty
+    image: linuxkit/getty:v0.2
+    env:
+     - INSECURE=true
+  - name: stress
+    image: stress
+    binds:
+      - /dev/sda:/dev/sda
+    pid: "host"
+    command: ["/bin/sh", "-c", "/stress.exe -stop-after 1024 -path /dev/sda && /sbin/halt"]
+trust:
+  org:
+    - linuxkit


### PR DESCRIPTION
DISCARD/TRIM support allows an application to signal to the disk that a range of sectors does not contain useful data and may be garbage collected. This is particularly useful on SSDs.

There are 3 implementations in this PR:
- for macOS running APFS, we use `fcntl(F_PUNCHHOLE)`
- for Linux with sparse files, we use `fallocate(FALLOC_FL_PUNCH_HOLE)`
- for Linux with block devices, we use `ioctl(BLKDISCARD)`

This PR includes a deterministic write, discard, read test which pseudo-randomly writes and occasionally discards regions, always reading back the disk contents to verify they are as expected. The stress test may be run locally via `make test`, or in a VM via `make vm-test`. Note the VM test requires https://github.com/linuxkit/linuxkit to be installed.