### PR TITLE
Add resize on Windows, prepare v2.10.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v2.10.0 (2018-06-11)
+* Add support for `discard` (also known as TRIM)
+* Add support for `resize` on Windows
+
 ## v2.9.0 (2017-12-07)
 * Add support for `flock` file locking
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -461,9 +461,7 @@ let resize t new_size_sectors =
   match t.fd with
   | None -> return (Error `Disconnected)
   | Some fd ->
-    if is_win32
-    then return (Error `Unimplemented)
-    else lwt_wrap_exn t "ftruncate" new_size_bytes
+    lwt_wrap_exn t "ftruncate" new_size_bytes
         (fun () ->
            Lwt_mutex.with_lock t.m
              (fun () ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -244,10 +244,6 @@ let test_not_multiple_of_sectors () =
     ) in
   Lwt_main.run t
 
-let not_implemented_on_windows = [
-  "test resize" >:: test_resize;
-]
-
 let tests = [
   "test ENOENT" >:: test_enoent;
   "test open read" >:: test_open_read;
@@ -262,7 +258,8 @@ let tests = [
   "test write then read" >:: test_write_read;
   "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
   "files which aren't a whole number of sectors" >:: test_not_multiple_of_sectors;
-] @ (if Sys.os_type <> "Win32" then not_implemented_on_windows else [])
+  "test resize" >:: test_resize;
+]
 
 let _ =
   Logs.set_reporter (Logs_fmt.reporter ());


### PR DESCRIPTION
Since we now have support for `ftruncate` (via `chsize_s`) on Windows, we can now implement `resize`.