### PR TITLE
Fix cstruct-lwt library name

### DIFF
--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,6 @@
 (executables
  (names benchmark test stress)
- (libraries lwt cstruct.lwt mirage-block-unix cstruct io-page io-page.unix
+ (libraries lwt cstruct-lwt mirage-block-unix cstruct io-page io-page.unix
    logs logs.fmt oUnit diet)
  (preprocess
   (pps ppx_sexp_conv)))


### PR DESCRIPTION
https://discuss.ocaml.org/t/psa-cstruct-3-4-0-removes-old-ocamlfind-subpackage-aliases/3275