### PR TITLE
Some build fixes for modern io-page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v2.11.2 (2019-05-11)
+* Fix test use of io-page-unix to work with io-page>2.0.0 (@avsm)
+* Remove unnecessary opam dependencies and refine `ppx_sexp_conv` one (@avsm)
+
 ## v2.11.1 (2019-03-10)
 * Fix some warnings in dev mode (#94 @emillon)
 * Clarify documentation about behaviour of `discard` (#95 @g2p)

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,6 +1,6 @@
 (executables
  (names benchmark test stress)
- (libraries lwt cstruct-lwt mirage-block-unix cstruct io-page io-page.unix
+ (libraries lwt cstruct-lwt mirage-block-unix cstruct io-page io-page-unix
    logs logs.fmt oUnit diet)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -20,9 +20,7 @@ depends: [
   "ounit" {with-test}
   "diet" {with-test}
   "fmt" {with-test}
-  "ppx_tools" {with-test}
-  "ppx_sexp_conv" {with-test}
-  "ppx_type_conv" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0" & with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
* Fix test use of io-page-unix to work with io-page>2.0.0 (@avsm)
* Remove unnecessary opam dependencies and refine `ppx_sexp_conv` one (@avsm)

Found in revdeps for the cstruct-5 release in
https://github.com/ocaml/opam-repository/pull/14001