### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -9,7 +9,7 @@ tags:         "org:mirage"
 license:      "ISC"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >="1.0"}
+  "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"
   "mirage-block-lwt" {>= "1.0.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.