### PR TITLE
adapt to mirage-block 2.0.0 changes, also fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
    - PACKAGE="mirage-block-unix"
    - TESTS=true
  matrix:
-   - DISTRO=alpine OCAML_VERSION=4.07
-   - DISTRO=debian-stable OCAML_VERSION=4.05
+   - DISTRO=alpine OCAML_VERSION=4.09
+   - DISTRO=debian-stable OCAML_VERSION=4.08
    - DISTRO=debian-stable OCAML_VERSION=4.07
    - DISTRO=ubuntu-lts OCAML_VERSION=4.06
-   - DISTRO=ubuntu-lts OCAML_VERSION=4.07

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   FORK_BRANCH: master
   PACKAGE: mirage-block-unix
   CYG_ROOT: C:\cygwin64
-  PINS: "diet:git://github.com/djs55/ocaml-diet"
+  OPAM_SWITCH: 4.06.0+mingw64c
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -68,10 +68,6 @@ let ftruncate fd size =
 
 open Lwt
 
-type 'a io = 'a Lwt.t
-
-type page_aligned_buffer = Cstruct.t
-
 module Config = struct
   type sync_behaviour = [
     | `ToOS

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -17,7 +17,7 @@
 
 (** Block device on top of {!Lwt_unix} *)
 
-include Mirage_block_lwt.S
+include Mirage_block.S
 
 (** {2 Low-level convenience functions} *)
 
@@ -62,32 +62,32 @@ module Config: sig
   (** Parse the result of a previous [to_string] invocation *)
 end
 
-val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> ?lock:bool -> string -> t io
+val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> ?lock:bool -> string -> t Lwt.t
 (** [connect ?buffered ?sync ?lock path] connects to a block device on the filesystem
     at [path]. By default I/O is buffered and asynchronous. By default the file
     is unlocked. These defaults
     can be changed by supplying the optional arguments [~buffered:false] and
     [~sync:false] [~lock:true] *)
 
-val resize : t -> int64 -> (unit, write_error) result io
+val resize : t -> int64 -> (unit, write_error) result Lwt.t
 (** [resize t new_size_sectors] attempts to resize the connected device
     to have the given number of sectors. If successful, subsequent calls
     to [get_info] will reflect the new size. *)
 
-val flush : t -> (unit, write_error) result io
+val flush : t -> (unit, write_error) result Lwt.t
 (** [flush t] flushes any buffers, if the file has been opened in buffered
     mode *)
 
-val seek_unmapped: t -> int64 -> (int64, error) result io
+val seek_unmapped: t -> int64 -> (int64, error) result Lwt.t
 (** [seek_unmapped t start] returns the sector offset of the next guaranteed
     zero-filled region (typically guaranteed because it is unmapped) *)
 
-val seek_mapped: t -> int64 -> (int64, error) result io
+val seek_mapped: t -> int64 -> (int64, error) result Lwt.t
 (** [seek_mapped t start] returns the sector offset of the next regoin of the
     device which may have data in it (typically this is the next mapped
     region) *)
 
-val discard: t -> int64 -> int64 -> (unit, write_error) result io
+val discard: t -> int64 -> int64 -> (unit, write_error) result Lwt.t
 (** [discard sector n] signals that the [n] sectors starting at [sector]
     are no longer needed and the contents may be discarded.
     Reads following the discard will return zeroes.
@@ -97,5 +97,5 @@ val discard: t -> int64 -> int64 -> (unit, write_error) result io
 val to_config: t -> Config.t
 (** [to_config t] returns the configuration of a device *)
 
-val of_config: Config.t -> t io
+val of_config: Config.t -> t Lwt.t
 (** [of_config config] creates a fresh device from [config] *)

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name mirage_block_unix)
  (public_name mirage-block-unix)
- (libraries cstruct-lwt logs uri rresult mirage-block-lwt)
+ (libraries cstruct-lwt logs uri rresult mirage-block)
  (wrapped false)
  (c_names odirect_stubs blkgetsize_stubs lseekhole_stubs flush_stubs
    writev_stubs readv_stubs flock_stubs discard_stubs chsize_stubs))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,9 +1,7 @@
 (executables
  (names benchmark test stress)
  (libraries lwt cstruct-lwt mirage-block-unix cstruct io-page io-page-unix
-   logs logs.fmt oUnit diet)
- (preprocess
-  (pps ppx_sexp_conv)))
+   logs logs.fmt oUnit diet))
 
 (alias
  (name runtest)

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -8,19 +8,18 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"
-  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-block" {>= "2.0.0"}
   "rresult"
   "io-page-unix" {>= "2.0.0"}
   "uri" {>= "1.9.0"}
   "logs"
   "ounit" {with-test}
-  "diet" {with-test}
+  "diet" {with-test & >= "0.4"}
   "fmt" {with-test}
-  "ppx_sexp_conv" {>= "v0.9.0" & with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -20,13 +20,13 @@ depends: [
   "ounit" {with-test}
   "diet" {with-test & >= "0.4"}
   "fmt" {with-test}
+  "conf-linux-libc-dev" {os = "linux"}
 ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-depexts: ["linux-headers"] {os-distribution = "alpine"}
 synopsis: "MirageOS disk block driver for Unix"
 description: """
 Unix implementation of the Mirage `BLOCK_DEVICE` interface.


### PR DESCRIPTION
`diet` changes removed to/of_sexp in 0.4 https://github.com/mirage/ocaml-diet/commit/57a67e7133abbfd413e58118a4ae1508b2d2a137#diff-28755396a6e17f4c0af01189b4bb1807