### PR TITLE
Fix tests on some Linux systems

### DIFF
--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -250,7 +250,9 @@ let _ =
     let path_already_exists = Sys.file_exists path in
     ( if not path_already_exists then create_file path sectors else Lwt.return_unit )
     >>= fun () ->
-    Block.connect ~buffered:false path
+    (* NOTE: This is buffered because open(2) with O_DIRECT will fail with
+       EINVAL on some Linux systems. *)
+    Block.connect ~buffered:true path
     >>= fun block ->
 
     Lwt.catch


### PR DESCRIPTION
On some Linux systems the tests fail with:
```
+ /home/opam/.opam/4.10.0/bin/dune "runtest" "-p" "mirage-block-unix" "-j" "71" (CWD=/home/opam/.opam/4.10.0/.opam-switch/build/mirage-block-unix.2.12.0)
-       stress alias lib_test/runtest (exit 2)
- (cd _build/default/lib_test && ./stress.exe)
- stress.exe: [ERROR] connect ./65536.compact: failed to open file
- Fatal error: exception Failure("connect ./65536.compact: failed to open file")
-         test alias lib_test/runtest
- test.exe: [ERROR] connect /tmp/mirage-block-test.6196.0: failed to open file
- ..test.exe: [ERROR] read beyond end of file: sector_start (2046) + len (3) > size_sectors (2048)
- test.exe: [ERROR] read: End_of_file at file /tmp/mirage-block-test.6196.1 offset 1047552 with buffers of length [ 512, 1024 ]
- .rm /tmp/mirage-block-test.6196.2
- ....rm /tmp/mirage-block-test.6196.2
- .test.exe: [ERROR] write: buffer length (511) is not a multiple of sector_size (512) for file /tmp/mirage-block-test.6196.2
- rm /tmp/mirage-block-test.6196.2
- ...
- Ran: 11 tests in: 0.12 seconds.
- OK
```
The issue is that `O_DIRECT` is defined but not supported. To fix that I switched the stress test to buffered mode. Feel free to change it the way you prefer if I got the fix wrong.