### PR TITLE
stress: run test in default (buffered) mode

### DIFF
--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -250,7 +250,7 @@ let _ =
     let path_already_exists = Sys.file_exists path in
     ( if not path_already_exists then create_file path sectors else Lwt.return_unit )
     >>= fun () ->
-    Block.connect ~buffered:false path
+    Block.connect path
     >>= fun block ->
 
     Lwt.catch


### PR DESCRIPTION
This is faster, and the choice of using or not the kernel caches is
orthogonal to this test.

Signed-off-by: David Scott <dave@recoil.org>