### PR TITLE
Add a configuration field for the size of sectors

### DIFF
--- a/lib/block.mli
+++ b/lib/block.mli
@@ -47,12 +47,20 @@ module Config: sig
     sync: sync_behaviour option;
     path: string; (** path to the underlying file *)
     lock: bool; (** true if the file should be locked preventing concurrent modification *)
+    prefered_sector_size : int option;
+        (** the size of sectors when it cannot be determined automatically *)
   }
   (** Configuration of a device *)
 
-  val create: ?buffered:bool -> ?sync:(sync_behaviour option) -> ?lock:bool -> string -> t
-  (** [create ?buffered ?sync ?lock path] constructs a configuration referencing the
-      file stored at [path]. *)
+  val create :
+    ?buffered:bool ->
+    ?sync:sync_behaviour option ->
+    ?lock:bool ->
+    ?prefered_sector_size:int option ->
+    string ->
+    t
+  (** [create ?buffered ?sync ?lock path] constructs a configuration referencing
+      the file stored at [path]. *)
 
   val to_string: t -> string
   (** Marshal a config into a string of the form
@@ -62,12 +70,20 @@ module Config: sig
   (** Parse the result of a previous [to_string] invocation *)
 end
 
-val connect : ?buffered:bool -> ?sync:(Config.sync_behaviour option) -> ?lock:bool -> string -> t Lwt.t
-(** [connect ?buffered ?sync ?lock path] connects to a block device on the filesystem
-    at [path]. By default I/O is buffered and asynchronous. By default the file
-    is unlocked. These defaults
-    can be changed by supplying the optional arguments [~buffered:false] and
-    [~sync:false] [~lock:true] *)
+val connect :
+  ?buffered:bool ->
+  ?sync:Config.sync_behaviour option ->
+  ?lock:bool ->
+  ?prefered_sector_size:int option ->
+  string ->
+  t Lwt.t
+(** [connect ?buffered ?sync ?lock ?prefered_sector_size path] connects to a
+    block device on the filesystem at [path]. By default I/O is buffered and
+    asynchronous. By default the file is unlocked. The size of sectors is
+    choosen automatically for block devices, [prefered_sector_size] is used for
+    regular files, the default value is [512]. These defaults can be changed by
+    supplying the optional arguments [~buffered:false] and [~sync:false]
+    [~lock:true] *)
 
 val resize : t -> int64 -> (unit, write_error) result Lwt.t
 (** [resize t new_size_sectors] attempts to resize the connected device

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -251,9 +251,9 @@ let tests = [
   *)
   "test read/write after last sector" >:: test_eof;
   "test flush" >:: test_flush;
-  test_parse_print_config { Block.Config.buffered = true; sync = None; path = "C:\\cygwin"; lock = false };
-  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToOS; path = "/var/tmp/foo.qcow2"; lock = false };
-  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToDrive; path = "/var/tmp/foo.qcow2"; lock = true };
+  test_parse_print_config { Block.Config.buffered = true; sync = None; path = "C:\\cygwin"; lock = false; prefered_sector_size = None };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToOS; path = "/var/tmp/foo.qcow2"; lock = false; prefered_sector_size = Some 4096 };
+  test_parse_print_config { Block.Config.buffered = false; sync = Some `ToDrive; path = "/var/tmp/foo.qcow2"; lock = true; prefered_sector_size = None };
   "test write then read" >:: test_write_read;
   "test that writes fail if the buffer has a bad length" >:: test_buffer_wrong_length;
   "files which aren't a whole number of sectors" >:: test_not_multiple_of_sectors;


### PR DESCRIPTION
This PR adds a configuration field to choose the size of sectors. It applies only for regular files, for which there is no universal best size and if there was, it would be a lot bigger.

Smaller sectors means more frequent IO and bigger data structures to manage them.
Due to cache and "readahead" in linux, the best size for `read` and `write` is huge (https://eklitzke.org/efficient-file-copying-on-linux).
The best size for random access inside buffers and having a lot of buffers is probably a lot less, in my case 8K seems the right size.
`512` is `64` OCaml words, `Cstruct.t` is `4`, Stdlib's `Map` nodes are `6`, a list node is `3`, `int64` is `3` so it's easy to have a quarter of the memory used for managing the sectors.

It also allows to use `io_page` to allocate buffers ([which uses 4096](https://github.com/mirage/io-page/blob/062e5f576e288eb15150e03b350d1db3585bf290/lib/io_page.ml#L23)), thought the name `prefered_sector_size` doesn't give enough confidence to do that.