### PR TITLE
Update to Cstruct.6.0.0 to fix depreciation warnings

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name mirage_block_unix)
  (public_name mirage-block-unix)
- (libraries cstruct-lwt logs uri rresult mirage-block)
+ (libraries cstruct cstruct-lwt io-page logs lwt uri rresult mirage-block)
  (wrapped false)
  (c_names odirect_stubs blkgetsize_stubs lseekhole_stubs flush_stubs
    writev_stubs readv_stubs flock_stubs discard_stubs chsize_stubs))

--- a/lib_test/benchmark.ml
+++ b/lib_test/benchmark.ml
@@ -18,8 +18,8 @@
 
 let split_into buf into =
   let rec loop acc remaining =
-    if Cstruct.len remaining = 0 then List.rev acc else begin
-      let to_take = min into (Cstruct.len remaining) in
+    if Cstruct.length remaining = 0 then List.rev acc else begin
+      let to_take = min into (Cstruct.length remaining) in
       loop (Cstruct.sub remaining 0 to_take :: acc) (Cstruct.shift remaining to_take)
     end in
   loop [] buf

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,7 +1,7 @@
 (executables
  (names benchmark test stress)
  (libraries lwt cstruct-lwt mirage-block-unix cstruct io-page io-page-unix
-   logs logs.fmt oUnit diet))
+   logs logs.fmt ounit2 diet))
 
 (alias
  (name runtest)

--- a/lib_test/stress.ml
+++ b/lib_test/stress.ml
@@ -57,7 +57,7 @@ module Make(B: DISCARDABLE) = struct
         assert (n <= buffer_size_sectors);
         let buf = Cstruct.sub write_buffer 0 (Int64.to_int n * info.Mirage_block.sector_size) in
         let rec for_each_sector x remaining =
-          if Cstruct.len remaining = 0 then () else begin
+          if Cstruct.length remaining = 0 then () else begin
             let sector = Cstruct.sub remaining 0 512 in
             (* Only write the first byte *)
             Cstruct.BE.set_uint64 sector 0 x;
@@ -126,7 +126,7 @@ module Make(B: DISCARDABLE) = struct
               | Error _ -> failwith "read"
               | Ok () ->
                 let rec for_each_sector x remaining =
-                  if Cstruct.len remaining = 0 then () else begin
+                  if Cstruct.length remaining = 0 then () else begin
                     let expected = p x in
                     let sector = Cstruct.sub remaining 0 512 in
                     check_contents x sector expected;

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -216,7 +216,7 @@ let test_not_multiple_of_sectors () =
         | Ok () ->
         let message' = Cstruct.(to_string (sub sector 0 (String.length message))) in
         assert_equal ~printer:(fun x -> x) message message';
-        for i = String.length message to Cstruct.len sector - 1 do
+        for i = String.length message to Cstruct.length sector - 1 do
           assert_equal ~printer:string_of_int 0 (Cstruct.get_uint8 sector i)
         done;
         (* We should be able to write 1 sector *)
@@ -228,7 +228,7 @@ let test_not_multiple_of_sectors () =
         Block.read device 0L [ sector ] >>= function
         | Error _ -> failwith (Printf.sprintf "Block.read %s: failed to read sector 0" file)
         | Ok () ->
-        for i = 0 to Cstruct.len sector - 1 do
+        for i = 0 to Cstruct.length sector - 1 do
           assert_equal ~printer:string_of_int 0xff (Cstruct.get_uint8 sector i)
         done;
         (* The file should still be 1 sector in length *)

--- a/lib_test/utils.ml
+++ b/lib_test/utils.ml
@@ -224,12 +224,12 @@ exception Cstruct_differ
 let cstruct_equal a b =
   let check_contents a b =
     try
-      for i = 0 to Cstruct.len a - 1 do
+      for i = 0 to Cstruct.length a - 1 do
         let a' = Cstruct.get_char a i in
         let b' = Cstruct.get_char b i in
         if a' <> b' then raise Cstruct_differ
       done;
       true
     with _ -> false in
-  (Cstruct.len a = (Cstruct.len b)) && (check_contents a b)
+  (Cstruct.length a = (Cstruct.length b)) && (check_contents a b)
 

--- a/mirage-block-unix.opam
+++ b/mirage-block-unix.opam
@@ -9,15 +9,17 @@ tags:         "org:mirage"
 license:      "ISC"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {>="1.0"}
-  "cstruct" {>= "3.0.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
   "cstruct-lwt"
   "mirage-block" {>= "2.0.0"}
   "rresult"
-  "io-page-unix" {>= "2.0.0"}
   "uri" {>= "1.9.0"}
   "logs"
-  "ounit" {with-test}
+  "lwt" {>= "5.4.2"}
+  "io-page" {>= "2.0.0"}
+  "io-page-unix" {with-test & >= "2.0.0"}
+  "ounit2" {with-test}
   "diet" {with-test & >= "0.4"}
   "fmt" {with-test}
   "conf-linux-libc-dev" {os = "linux"}


### PR DESCRIPTION
 Update to Cstruct.6.0.0 to fix depreciation warnings

Also update the opam and dune files to fix linting warnings.