### PR TITLE
Use caml/unixsupport.h instead of extern

### DIFF
--- a/lib/blkgetsize_stubs.c
+++ b/lib/blkgetsize_stubs.c
@@ -31,6 +31,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
+#include <caml/unixsupport.h>
 
 #ifdef __linux__
 #include <linux/fs.h>
@@ -111,10 +112,6 @@ int blkgetsectorsize(int fd, int *size)
 #else
 # error "Unable to query block device size: unsupported platform, please report."
 #endif
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
 
 CAMLprim value stub_blkgetsize(value fd){
   CAMLparam1(fd);

--- a/lib/flock_stubs.c
+++ b/lib/flock_stubs.c
@@ -24,9 +24,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
+#include <caml/unixsupport.h>
 
 CAMLprim value stub_flock(value fd, value ex, value nb){
   CAMLparam3(fd, ex, nb);

--- a/lib/lseekhole_stubs.c
+++ b/lib/lseekhole_stubs.c
@@ -28,10 +28,7 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include <caml/fail.h>
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
+#include <caml/unixsupport.h>
 
 CAMLprim value stub_lseek_data_64(value fd, value ofs){
   CAMLparam2(fd, ofs);

--- a/lib/odirect_stubs.c
+++ b/lib/odirect_stubs.c
@@ -30,10 +30,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
+#include <caml/unixsupport.h>
 
 CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
   CAMLparam3(filename, rw, perm);


### PR DESCRIPTION
While performing impact testing for https://github.com/ocaml/ocaml/pull/10926, I found this presumably older code which declared `uerror` as an `extern`. `caml/unixsupport.h` declares this function, which means that the code carries on working if we rename `uerror` (which we're planning on doing in 5.0!).

This PR could be merged regardless of the upstream OCaml PR.