### PR TITLE
Add `Block.with_block` to limit the lifetime of a connected block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Add `Block.with_block` to limit the lifetime of a connected block. (#???, @MisterDA)
+
 ## v2.14.2 (2022-09-15)
 
 * Raise an exception on connect if the file is not aligned to the `sector_size` (#117, @reynir)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -237,6 +237,10 @@ let disconnect t = match t.fd with
   | None ->
     return ()
 
+let with_block ?buffered ?sync ?lock ?prefered_sector_size name f =
+  connect ?buffered ?sync ?lock ?prefered_sector_size name >>= fun b ->
+  Lwt.finalize (fun () -> f b) (fun () -> disconnect b)
+
 let get_info x = return x.info
 
 let really_read fd = Lwt_cstruct.complete (Lwt_cstruct.read fd)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -85,6 +85,19 @@ val connect :
     supplying the optional arguments [~buffered:false] and [~sync:false]
     [~lock:true] *)
 
+val with_block :
+  ?buffered:bool ->
+  ?sync:Config.sync_behaviour option ->
+  ?lock:bool ->
+  ?prefered_sector_size:int option ->
+  string ->
+  (t -> 'a Lwt.t) ->
+  'a Lwt.t
+(** [with_block ?buffered ?sync ?lock ?prefered_sector_size path f] connects to
+    a block device (see {!connect}), calls [f b] where [b] is the block device,
+    and calls {!disconnect} on [b] whatever the outcome is. Useful for resource
+    conctrol. *)
+
 val resize : t -> int64 -> (unit, write_error) result Lwt.t
 (** [resize t new_size_sectors] attempts to resize the connected device
     to have the given number of sectors. If successful, subsequent calls


### PR DESCRIPTION
Motivated by Windows bugfixing on in tests of ocaml-tar.
On Windows, opened files (without a set of special flags) cannot be moved, renamed, deleted if there are opened file descriptors to them. As it is common to forget to disconnect the device, add this function for resource control.