### PR TITLE
Remove fprintf call from C stubs

### DIFF
--- a/lib/chsize_stubs.c
+++ b/lib/chsize_stubs.c
@@ -53,7 +53,6 @@ errno_t _chsize_s(int fd, int64_t size) {
 #include <stdio.h>
 static void worker_chsize(struct job_chsize *job)
 {
-fprintf(stderr, "fd = %d\n", job->fd);
   job->errno_copy = _chsize_s(job->fd, job->size);
 }
 


### PR DESCRIPTION
The commit description is probably inaccurate. I can't see why it should only affect Windows. Nonetheless I have only observed it in the output of Windows CI jobs.